### PR TITLE
Add sentence-transformers dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "numpy>=1.24",
   "scikit-learn>=1.3",
   "shellingham>=1.5",
+  "sentence-transformers>=2.7",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- include `sentence-transformers` in project dependencies for semantic features

## Testing
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=68)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'smartchunk')*

------
https://chatgpt.com/codex/tasks/task_e_68bef25a1cc08328927f270ea0694d2e