### PR TITLE
Strip footer and aside elements from HTML parser

### DIFF
--- a/src/smartchunk/parsers.py
+++ b/src/smartchunk/parsers.py
@@ -18,7 +18,7 @@ def parse_html(html_content: str) -> str:
     # --- In-Place Transformations on the Soup Object ---
 
     # Decompose (remove) all tags that are not useful for text content, like styles and scripts.
-    for tag in soup.find_all(['script', 'style', 'nav', 'header']):
+    for tag in soup.find_all(['script', 'style', 'nav', 'header', 'footer', 'aside']):
         tag.decompose()
 
     # Convert header tags to Markdown header syntax


### PR DESCRIPTION
## Summary
- ensure HTML parser removes non-content tags including `footer` and `aside` before extracting text

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf0219dfbc8328919a2ce20f505a5f